### PR TITLE
feat: Manage executable path in darlingserver

### DIFF
--- a/internal-include/darlingserver/process.hpp
+++ b/internal-include/darlingserver/process.hpp
@@ -171,8 +171,8 @@ namespace DarlingServer {
 		std::shared_ptr<Process> tracerProcess() const;
 		bool setTracerProcess(std::shared_ptr<Process> tracerProcess);
 
-		const std::string& executablePath() const;
-		void setExecutablePath(const char* path);
+		std::string executablePath() const;
+		void setExecutablePath(std::string path);
 
 		uintptr_t allocatePages(size_t pageCount, int protection, uintptr_t addressHint, bool fixed, bool overwrite);
 		void freePages(uintptr_t address, size_t pageCount);

--- a/internal-include/darlingserver/process.hpp
+++ b/internal-include/darlingserver/process.hpp
@@ -88,6 +88,7 @@ namespace DarlingServer {
 		dtape_semaphore_t* _dtapeForkWaitSemaphore;
 		Architecture _architecture;
 		std::weak_ptr<Process> _tracerProcess;
+		std::string _executablePath;
 
 #if DSERVER_EXTENDED_DEBUG
 		std::unordered_map<uint32_t, uintptr_t> _registeredNames;
@@ -169,6 +170,9 @@ namespace DarlingServer {
 
 		std::shared_ptr<Process> tracerProcess() const;
 		bool setTracerProcess(std::shared_ptr<Process> tracerProcess);
+
+		const std::string& executablePath() const;
+		void setExecutablePath(const char* path);
 
 		uintptr_t allocatePages(size_t pageCount, int protection, uintptr_t addressHint, bool fixed, bool overwrite);
 		void freePages(uintptr_t address, size_t pageCount);

--- a/scripts/generate-rpc-wrappers.py
+++ b/scripts/generate-rpc-wrappers.py
@@ -233,7 +233,9 @@ calls = [
 		('pid', 'int32_t'),
 		('buffer', 'char*', 'uint64_t'),
 		('buffer_size', 'uint64_t')
-	], []),
+	], [
+		('length', 'uint64_t'),
+	]),
 
 	#
 	# kqueue channels

--- a/scripts/generate-rpc-wrappers.py
+++ b/scripts/generate-rpc-wrappers.py
@@ -224,6 +224,17 @@ calls = [
 
 	('s2c_perform', [], []),
 
+	('set_executable_path', [
+		('buffer', 'const char*', 'uint64_t'),
+		('buffer_size', 'uint64_t')
+	], []),
+
+	('get_executable_path', [
+		('pid', 'int32_t'),
+		('buffer', 'char*', 'uint64_t'),
+		('buffer_size', 'uint64_t')
+	], []),
+
 	#
 	# kqueue channels
 	#

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -585,14 +585,14 @@ std::shared_ptr<DarlingServer::Thread> DarlingServer::Process::_pickS2CThread(vo
 	return thread;
 };
 
-const std::string& DarlingServer::Process::executablePath() const {
+std::string DarlingServer::Process::executablePath() const {
 	std::shared_lock lock(_rwlock);
 	return _executablePath;
 };
 
-void DarlingServer::Process::setExecutablePath(const char* path) {
+void DarlingServer::Process::setExecutablePath(std::string path) {
 	std::unique_lock lock(_rwlock);
-	_executablePath = std::string(path);
+	_executablePath = std::move(path);
 };
 
 uintptr_t DarlingServer::Process::allocatePages(size_t pageCount, int protection, uintptr_t addressHint, bool fixed, bool overwrite) {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -585,6 +585,16 @@ std::shared_ptr<DarlingServer::Thread> DarlingServer::Process::_pickS2CThread(vo
 	return thread;
 };
 
+const std::string& DarlingServer::Process::executablePath() const {
+	std::shared_lock lock(_rwlock);
+	return _executablePath;
+};
+
+void DarlingServer::Process::setExecutablePath(const char* path) {
+	std::unique_lock lock(_rwlock);
+	_executablePath = std::string(path);
+};
+
 uintptr_t DarlingServer::Process::allocatePages(size_t pageCount, int protection, uintptr_t addressHint, bool fixed, bool overwrite) {
 	auto thread = _pickS2CThread();
 


### PR DESCRIPTION
This commit contains infrastructure changes to `darlingserver` to allow functions such as `_proc_pidinfo_pathinfo` to query the executable path of processes.

The previous kernel module implementation uses `/proc/[pid]/exe`, but now this path contains the `mldr` binary instead of the real Mach-O executable.