### PR TITLE
Use dtape_stub_safe() for HOST_CPU_LOAD_INFO

### DIFF
--- a/duct-tape/src/host.c
+++ b/duct-tape/src/host.c
@@ -211,6 +211,10 @@ kern_return_t host_statistics(host_t host, host_flavor_t flavor, host_info_t inf
 			dtape_stub_safe("HOST_VM_INFO");
 			return KERN_INVALID_ARGUMENT;
 
+		case HOST_CPU_LOAD_INFO:
+			dtape_stub_safe("HOST_CPU_LOAD_INFO");
+			return KERN_INVALID_ARGUMENT;
+
 		default:
 			dtape_stub_unsafe();
 	}


### PR DESCRIPTION
Avoid darlingserver crash when calling host_statistics()
asking for HOST_CPU_LOAD_INFO

`top` makes this call, at least cash top and not the
server