### PR TITLE
feat: Initial WSL1 support

### DIFF
--- a/internal-include/darlingserver/process.hpp
+++ b/internal-include/darlingserver/process.hpp
@@ -121,7 +121,7 @@ namespace DarlingServer {
 		using ID = pid_t;
 		using NSID = ID;
 
-		Process(ID id, NSID nsid, Architecture architecture);
+		Process(ID id, NSID nsid, Architecture architecture, int pipe = -1);
 		Process(KernelProcessConstructorTag tag);
 		~Process();
 

--- a/internal-include/darlingserver/thread.hpp
+++ b/internal-include/darlingserver/thread.hpp
@@ -148,7 +148,7 @@ namespace DarlingServer {
 
 		struct KernelThreadConstructorTag {};
 
-		Thread(std::shared_ptr<Process> process, NSID nsid);
+		Thread(std::shared_ptr<Process> process, NSID nsid, void* stackHint = nullptr);
 		Thread(KernelThreadConstructorTag tag);
 		~Thread() noexcept(false);
 

--- a/scripts/generate-rpc-wrappers.py
+++ b/scripts/generate-rpc-wrappers.py
@@ -107,6 +107,8 @@ calls = [
 
 	('checkin', [
 		('is_fork', 'bool'),
+		('stack_hint', 'void*', 'uint64_t'),
+		('lifetime_listener_pipe', '@fd')
 	], []),
 
 	('checkout', [

--- a/src/darlingserver.cpp
+++ b/src/darlingserver.cpp
@@ -179,7 +179,7 @@ void setupUserHome(const char* prefix, uid_t originalUID)
 		const char* dir = xdgDirectory(xdgmap[i][0]);
 		if (!dir)
 			continue;
-		
+
 		snprintf(buf2, sizeof(buf2), "/Volumes/SystemRoot%s", dir);
 		snprintf(buf, sizeof(buf), "%s/Users/%s/%s", prefix, login, xdgmap[i][1]);
 
@@ -398,6 +398,7 @@ int main(int argc, char** argv) {
 		nr_open_file = fopen("/proc/sys/fs/nr_open", "r");
 		if (nr_open_file == NULL) {
 			fprintf(stderr, "Warning: failed to open /proc/sys/fs/nr_open: %s\n", strerror(errno));
+			increased_limit.rlim_cur = increased_limit.rlim_max = default_limit.rlim_max;
 			//exit(1);
 		} else {
 			if (fscanf(nr_open_file, "%lu", &increased_limit.rlim_max) != 1) {
@@ -409,13 +410,14 @@ int main(int argc, char** argv) {
 				fprintf(stderr, "Failed to close /proc/sys/fs/nr_open: %s\n", strerror(errno));
 				exit(1);
 			}
-
-			// now set our increased rlimit
-			if (setrlimit(RLIMIT_NOFILE, &increased_limit) != 0) {
-				fprintf(stderr, "Warning: failed to increase FD rlimit: %s\n", strerror(errno));
-				//exit(1);
-			}
 		}
+
+		// now set our increased rlimit
+		if (setrlimit(RLIMIT_NOFILE, &increased_limit) != 0) {
+			fprintf(stderr, "Warning: failed to increase FD rlimit: %s\n", strerror(errno));
+			//exit(1);
+		}
+
 #endif
 	}
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -31,12 +31,12 @@
 
 static DarlingServer::Log processLog("process");
 
-DarlingServer::Process::Process(ID id, NSID nsid, Architecture architecture):
+DarlingServer::Process::Process(ID id, NSID nsid, Architecture architecture, int pipe):
 	_pid(id),
 	_nspid(nsid),
 	_architecture(architecture)
 {
-	int pidfd = syscall(SYS_pidfd_open, _pid, 0);
+	int pidfd = (pipe >= 0) ? pipe : syscall(SYS_pidfd_open, _pid, 0);
 	if (pidfd < 0) {
 		throw std::system_error(errno, std::generic_category(), "Failed to open pidfd for process");
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -34,6 +34,8 @@
 #include <darlingserver/duct-tape.h>
 #include <sys/timerfd.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
 
 #include <darlingserver/logging.hpp>
 
@@ -609,7 +611,7 @@ void DarlingServer::Server::start() {
 void DarlingServer::Server::monitorProcess(std::shared_ptr<Process> process) {
 	// the this-capture here is safe because the Server will always out-live everything else
 	std::weak_ptr<Process> weakProcess = process;
-	auto monitor = std::make_shared<Monitor>(process->_pidfd, Monitor::Event::Readable, false, false, [this, weakProcess](std::shared_ptr<Monitor> thisMonitor, Monitor::Event events) {
+	auto monitor = std::make_shared<Monitor>(process->_pidfd, Monitor::Event::Readable | Monitor::Event::HangUp, false, false, [this, weakProcess](std::shared_ptr<Monitor> thisMonitor, Monitor::Event events) {
 		removeMonitor(thisMonitor);
 
 		auto process = weakProcess.lock();


### PR DESCRIPTION
Part of https://github.com/darlinghq/darling/issues/1206.

- Implemented an alternative to pidfd_open for kernels older than 5.3.
mldr should send a "lifetime pipe" to darlingserver during process start.
When the process dies, darlingserver should receive a POLLHUP event.
- Set increased_limit.rlim_cur to default_limit.rlim_max on systems without
/proc/sys/fs/nr_open. On WSL1, this greatly increases the number of open file
descriptors available.
- For systems without NSpid in /proc/self/status, implemented a way to manage
thread IDs in darlingserver during checkin. darlingserver should receive a hint
address on the thread's stack, and then compare it with a stack pointer retrieved using
PTRACE_GETREGS
- Avoided sending socket messages when msg_hdr.msg_name->sun_path is an empty string.
A null msg_name is used instead, otherwise, on some systems, this would fail with EINVAL.