### PR TITLE
bump cmake minimum required version to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(darlingserver)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 option(DSERVER_ASAN "Build darlingserver with ASAN" OFF)
 option(DSERVER_UBSAN "Build darlingserver with UBSAN" OFF)


### PR DESCRIPTION
The `CMakeLists.txt` of this project uses [add_compile_definitions](https://cmake.org/cmake/help/latest/command/add_compile_definitions.html) and [target_link_options](https://cmake.org/cmake/help/latest/command/target_link_options.html), these commands were respectively introduced on versions 3.12 and 3.13 of CMake. So the minimum version of CMake required to build this project is 3.13, not 3.10.

* Building with CMake 3.10
```
[root@ip-10-33-203-233 build]# cmake ..
-- The C compiler identification is Clang 11.1.0
-- The CXX compiler identification is Clang 11.1.0
-- Check for working C compiler: /bin/clang
-- Check for working C compiler: /bin/clang -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /bin/clang++
-- Check for working CXX compiler: /bin/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- The ASM compiler identification is Clang
-- Found assembler: /bin/clang
-- The ASM-ATT compiler identification is GNU
-- Found assembler: /bin/as
-- Found dsymutil: /bin/dsymutil
-- Found Setcap: /sbin/setcap  
-- Compiler include path detected as /usr/lib64/clang/11.1.0/include/
-- Found BISON: /bin/bison (found version "3.0.4") 
-- Found FLEX: /bin/flex (found version "2.5.37") 
CMake Error at src/external/darlingserver/CMakeLists.txt:13 (add_compile_definitions):
  Unknown CMake command "add_compile_definitions".


-- Configuring incomplete, errors occurred!
See also "/root/darling/build/CMakeFiles/CMakeOutput.log".
```

* Building with CMake 3.12
```
[root@ip-10-33-203-233 build]# cmake ..
-- The C compiler identification is Clang 11.1.0
-- The CXX compiler identification is Clang 11.1.0
-- Check for working C compiler: /bin/clang
-- Check for working C compiler: /bin/clang -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /bin/clang++
-- Check for working CXX compiler: /bin/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- The ASM compiler identification is unknown
-- Found assembler: /bin/clang
-- Warning: Did not find file Compiler/-ASM
-- The ASM-ATT compiler identification is GNU
-- Found assembler: /bin/as
-- Found dsymutil: /bin/dsymutil
-- Compiler include path detected as /usr/lib64/clang/11.1.0/include/
CMake Error at src/external/darlingserver/CMakeLists.txt:130 (target_link_options):
  Unknown CMake command "target_link_options".


-- Configuring incomplete, errors occurred!
See also "/root/darling/build/CMakeFiles/CMakeOutput.log".
See also "/root/darling/build/CMakeFiles/CMakeError.log".
```

* Compiling with CMake 3.13
```
[root@ip-10-33-203-233 build]# cmake ..
-- The C compiler identification is Clang 11.1.0
-- The CXX compiler identification is Clang 11.1.0
-- Check for working C compiler: /bin/clang
-- Check for working C compiler: /bin/clang -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /bin/clang++
-- Check for working CXX compiler: /bin/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- The ASM compiler identification is Clang
-- Found assembler: /bin/clang
-- The ASM-ATT compiler identification is GNU
-- Found assembler: /bin/as
-- Found dsymutil: /bin/dsymutil
-- Found Setcap: /sbin/setcap  
-- Compiler include path detected as /usr/lib64/clang/11.1.0/include/
-- Found BISON: /bin/bison (found version "3.0.4") 
-- Found FLEX: /bin/flex (found version "2.5.37") 
-- Found PkgConfig: /bin/pkg-config (found version "0.27.1") 
-- Checking for module 'fuse'
--   Found fuse, version 2.9.2
-- Checking for module 'libavcodec'
--   No package 'libavcodec' found
-- Checking for module 'libavformat'
--   No package 'libavformat' found
-- Checking for module 'libavutil'
--   No package 'libavutil' found
-- Found FFMPEG or Libav: /usr/lib/libavcodec.so;/usr/lib/libavformat.so;/usr/lib/libavutil.so, /usr/include
-- Found FFmpeg: /usr/lib/libavcodec.so;/usr/lib/libavformat.so;/usr/lib/libavutil.so  
-- Found PulseAudio: /usr/lib64/libpulse.so  
-- Looking for XOpenDisplay in /usr/lib64/libX11.so;/usr/lib64/libXext.so
-- Looking for XOpenDisplay in /usr/lib64/libX11.so;/usr/lib64/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Found X11: /usr/lib64/libX11.so
-- Checking for one of the modules 'openssl'
-- Performing Test CFLAG_Wall
-- Performing Test CFLAG_Wall - Success
-- Performing Test CFLAG_Wno_unknown_pragmas
-- Performing Test CFLAG_Wno_unknown_pragmas - Success
-- Performing Test CFLAG_Wno_unused_variable
-- Performing Test CFLAG_Wno_unused_variable - Success
-- Checking for module 'cairo'
--   Found cairo, version 1.15.12
-- Found Freetype: /usr/lib64/libfreetype.so (found version "2.8.0") 
-- Found ZLIB: /usr/lib64/libz.so (found version "1.2.7") 
-- Found PNG: /usr/lib64/libpng.so (found version "1.5.13") 
-- Found TIFF: /usr/lib64/libtiff.so (found version "4.0.3") 
-- Found JPEG: /usr/lib64/libjpeg.so (found version "") 
-- Performing Test GIF_GifFileType_UserData
-- Performing Test GIF_GifFileType_UserData - Failed
-- Found GIF: /usr/lib64/libgif.so (found version "3") 
-- Checking for module 'fontconfig'
--   Found fontconfig, version 2.13.0
-- Found OpenGL: /usr/lib64/libOpenGL.so   
-- Checking for module 'egl'
--   Found egl, version 18.3.4
-- Checking for module 'dbus-1'
--   Found dbus-1, version 1.10.24
-- Configuring done
-- Generating done
-- Build files have been written to: /root/darling/build
```