### PR TITLE
Fix compiling on clang 15+

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -23,6 +23,7 @@
 #include <stdexcept>
 #include <new>
 #include <mutex>
+#include <system_error>
 
 DarlingServer::Address::Address() {
 	_address.sun_family = AF_UNIX;

--- a/src/stack-pool.cpp
+++ b/src/stack-pool.cpp
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <assert.h>
+#include <system_error>
 
 #if DSERVER_ASAN
 	#include <sanitizer/asan_interface.h>


### PR DESCRIPTION
Include the system_error.h header to fix issues with compiling on clang 15 and 16 (as well as potentially other versions)