### PR TITLE
Allow overriding xdg-user-dir executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ endif()
 add_subdirectory(duct-tape)
 
 set(DARLINGSERVER_INIT_PROCESS "/sbin/launchd" CACHE STRING "The init process darlingserver should execute (default is \"/sbin/launchd\")")
+set(DARLINGSERVER_XDG_USER_DIR_CMD "xdg-user-dir" CACHE STRING "The xdg-user-dir binary darlingserver should execute (default is \"xdg-user-dir\")")
 
 include_directories(
 	include
@@ -163,5 +164,11 @@ install(TARGETS darlingserver DESTINATION bin)
 if (NOT "${DARLINGSERVER_INIT_PROCESS}" STREQUAL "")
 	target_compile_definitions(darlingserver PRIVATE
 		DARLINGSERVER_INIT_PROCESS="${DARLINGSERVER_INIT_PROCESS}"
+	)
+endif()
+
+if (NOT "${DARLINGSERVER_XDG_USER_DIR_CMD}" STREQUAL "")
+	target_compile_definitions(darlingserver PRIVATE
+		DARLINGSERVER_XDG_USER_DIR_CMD="${DARLINGSERVER_XDG_USER_DIR_CMD}"
 	)
 endif()

--- a/src/darlingserver.cpp
+++ b/src/darlingserver.cpp
@@ -48,6 +48,10 @@
 	#define DARLINGSERVER_INIT_PROCESS "/sbin/launchd"
 #endif
 
+#ifndef DARLINGSERVER_XDG_USER_DIR_CMD
+	#define DARLINGSERVER_XDG_USER_DIR_CMD "xdg-user-dir"
+#endif
+
 #if DSERVER_ASAN
 	#include <sanitizer/lsan_interface.h>
 #endif
@@ -90,9 +94,9 @@ void fixPermissionsRecursive(const char* path, uid_t originalUID, gid_t original
 const char* xdgDirectory(const char* name)
 {
 	static char dir[4096];
-	char* cmd = (char*) malloc(16 + strlen(name));
+	char* cmd = (char*) malloc(sizeof(DARLINGSERVER_XDG_USER_DIR_CMD) + 1 + strlen(name));
 
-	sprintf(cmd, "xdg-user-dir %s", name);
+	sprintf(cmd, DARLINGSERVER_XDG_USER_DIR_CMD " %s", name);
 
 	FILE* proc = popen(cmd, "r");
 


### PR DESCRIPTION
This makes it easier to set the path as xdg-user-dir may not be in PATH.