### PR TITLE
Use mldr specific environment variable for DYLD_ROOT_PATH

### DIFF
--- a/src/darlingserver.cpp
+++ b/src/darlingserver.cpp
@@ -266,7 +266,7 @@ void spawnLaunchd(const char* prefix)
 		initPath = DARLINGSERVER_INIT_PROCESS;
 	}
 
-	setenv("DYLD_ROOT_PATH", LIBEXEC_PATH, 1);
+	setenv("__mldr_DYLD_ROOT_PATH", LIBEXEC_PATH, 1);
 	setenv("__mldr_sockpath", tmp.c_str(), 1);
 	execl(DarlingServer::Config::defaultMldrPath.data(), "mldr!" LIBEXEC_PATH "/usr/libexec/darling/vchroot", "vchroot", prefix, initPath, NULL);
 


### PR DESCRIPTION
This changes `DYLD_ROOT_PATH` to be passed to mldr using a mldr specific environment variable, rather than `DYLD_ROOT_PATH`.

Fix described in: https://github.com/darlinghq/darling/issues/1489#issuecomment-3595050574