### PR TITLE
arm64: detach launchd into its own session

### DIFF
--- a/duct-tape/CMakeLists.txt
+++ b/duct-tape/CMakeLists.txt
@@ -127,6 +127,10 @@ add_compile_definitions(
 	__DARWIN_BYTE_ORDER=__DARWIN_LITTLE_ENDIAN
 )
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+	add_compile_definitions(__arm64__ APPLE_ARM64_ARCH_FAMILY VMAPPLE ARM64_BOARD_CONFIG_VMAPPLE __ARM_VMSA__=8 __ARM64_PMAP_SUBPAGE_L1__)
+endif()
+
 add_compile_options(
 	-fblocks
 	-ffunction-sections
@@ -321,7 +325,7 @@ add_library(darlingserver_duct_tape STATIC
 	xnu/osfmk/ipc/mig_log.c
 	xnu/osfmk/ipc/ipc_eventlink.c
 
-	xnu/osfmk/i386/rtclock.c
+	$<IF:$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},aarch64>,src/rtclock_arm64.c,xnu/osfmk/i386/rtclock.c>
 
 	xnu/osfmk/prng/prng_random.c
 

--- a/duct-tape/internal-include/darlingserver/duct-tape/thread.h
+++ b/duct-tape/internal-include/darlingserver/duct-tape/thread.h
@@ -21,6 +21,9 @@ typedef struct dtape_thread_user_state {
 #if __x86_64__
 	x86_thread_state_t thread_state;
 	x86_float_state_t float_state;
+#elif __aarch64__
+	arm_unified_thread_state_t thread_state;
+	arm_neon_state64_t float_state;
 #endif
 } dtape_thread_user_state_t;
 

--- a/duct-tape/src/host.c
+++ b/duct-tape/src/host.c
@@ -65,6 +65,9 @@ kern_return_t host_info(host_t host, host_flavor_t flavor, host_info_t info, mac
 #else
 			basic_info->cpu_subtype = CPU_SUBTYPE_I386_ALL;
 #endif
+#elif __aarch64__
+			basic_info->cpu_type = CPU_TYPE_ARM64;
+			basic_info->cpu_subtype = CPU_SUBTYPE_ARM64_ALL;
 #else
 			#error Unknown CPU type
 #endif

--- a/duct-tape/src/linux_clock.h
+++ b/duct-tape/src/linux_clock.h
@@ -1,0 +1,22 @@
+#ifndef _DARLINGSERVER_DUCT_TAPE_LINUX_CLOCK_H_
+#define _DARLINGSERVER_DUCT_TAPE_LINUX_CLOCK_H_
+
+// Minimal declaration of the host's clock_gettime(CLOCK_MONOTONIC). duct-tape is
+// kernel-side XNU code and can't pull in <time.h> without dragging in conflicting
+// Darwin time types, so the timebase sources (timer.c and rtclock_arm64.c)
+// historically each redeclared these. Keep the single source of truth here.
+
+#define CLOCK_MONOTONIC 1
+
+// Darling's duct-tape only ever builds for 64-bit Linux hosts (x86_64 / arm64),
+// where struct timespec is two longs. Spell it out directly rather than copying
+// glibc's __WORDSIZE/__TIMESIZE/endian-conditional definition (which we can't
+// pull in via <time.h> here anyway).
+struct timespec {
+	long tv_sec;
+	long tv_nsec;
+};
+
+int clock_gettime(int clk_id, struct timespec *tp);
+
+#endif // _DARLINGSERVER_DUCT_TAPE_LINUX_CLOCK_H_

--- a/duct-tape/src/locks.c
+++ b/duct-tape/src/locks.c
@@ -68,7 +68,11 @@ void dtape_mutex_lock(dtape_mutex_t* mutex) {
 				return;
 			}
 			libsimple_lock_unlock(&mutex->dtape_queue_lock);
+#if __x86_64__ || __i386__
 			__builtin_ia32_pause();
+#elif __aarch64__
+			__asm__ volatile("yield");
+#endif
 		}
 	}
 
@@ -528,6 +532,8 @@ hw_wait_while_equals(void **address, void *current)
 #ifdef __DARLING__
 #if __x86_64__ || __i386__
 			__builtin_ia32_pause();
+#elif __aarch64__
+			__asm__ volatile("yield");
 #else
 			#warning Missing CPU pause for this architecture
 #endif

--- a/duct-tape/src/memory.c
+++ b/duct-tape/src/memory.c
@@ -363,13 +363,17 @@ int (copyout)(const void* kernel_addr, user_addr_t user_addr, vm_size_t nbytes) 
 	return (copyoutmap(current_map(), (void*)kernel_addr, user_addr, nbytes) == KERN_SUCCESS) ? 0 : 1;
 };
 
+#ifndef copyinmsg
 int copyinmsg(const user_addr_t user_addr, char* kernel_addr, mach_msg_size_t nbytes) {
 	return (copyin)(user_addr, kernel_addr, nbytes);
 };
+#endif
 
+#ifndef copyoutmsg
 int copyoutmsg(const char* kernel_addr, user_addr_t user_addr, mach_msg_size_t nbytes) {
 	return (copyout)(kernel_addr, user_addr, nbytes);
 };
+#endif
 
 kern_return_t kmem_suballoc(vm_map_t parent, vm_offset_t* addr, vm_size_t size, boolean_t pageable, int flags, vm_map_kernel_flags_t vmk_flags, vm_tag_t tag, vm_map_t* new_map) {
 	// this is enough to satisfy ipc_init

--- a/duct-tape/src/misc.c
+++ b/duct-tape/src/misc.c
@@ -12,6 +12,10 @@
 
 #include <sys/types.h>
 
+#if __aarch64__ || __arm64__
+#include <mach/arm/thread_status.h>
+#endif
+
 char version[] = "Darling 11.5";
 
 #if __x86_64__ || __i386__
@@ -39,6 +43,21 @@ char version[] = "Darling 11.5";
 		[x86_PAGEIN_STATE]              = x86_PAGEIN_STATE_COUNT
 	};
 	// </copied>
+#elif __aarch64__
+	unsigned int _MachineStateCount[] = {
+		[ARM_THREAD_STATE]              = ARM_THREAD_STATE_COUNT,
+		[ARM_VFP_STATE]                 = ARM_VFP_STATE_COUNT,
+		[ARM_EXCEPTION_STATE]           = ARM_EXCEPTION_STATE_COUNT,
+		[ARM_DEBUG_STATE]               = ARM_DEBUG_STATE_COUNT,
+		[ARM_THREAD_STATE64]            = ARM_THREAD_STATE64_COUNT,
+		[ARM_EXCEPTION_STATE64]         = ARM_EXCEPTION_STATE64_COUNT,
+		[ARM_THREAD_STATE32]            = ARM_THREAD_STATE32_COUNT,
+		[ARM_DEBUG_STATE32]             = ARM_DEBUG_STATE32_COUNT,
+		[ARM_DEBUG_STATE64]             = ARM_DEBUG_STATE64_COUNT,
+		[ARM_NEON_STATE]                = ARM_NEON_STATE_COUNT,
+		[ARM_NEON_STATE64]              = ARM_NEON_STATE64_COUNT,
+		[ARM_CPMU_STATE64]              = 0,
+	};
 #else
 	#error _MachineStateCount not defined on this architecture
 #endif
@@ -124,4 +143,58 @@ fls(unsigned int mask)
 // </copied>
 //
 
-#endif
+#endif /* __x86_64__ */
+
+#if __aarch64__ || __arm64__
+
+// ARM64-specific stubs and definitions
+
+#include <kern/simple_lock.h>
+
+// PAGE_SHIFT_CONST is extern on ARM64 (variable page size support in XNU).
+// Darling uses a fixed 4K page size.
+int PAGE_SHIFT_CONST = 12;
+
+// ARM simple lock init (normally in arm/locks_arm.c)
+void arm_usimple_lock_init(simple_lock_t l, unsigned short type) {
+	memset(l, 0, sizeof(*l));
+}
+
+// Thread task accessor (normally in kern/bsd_kern.c)
+task_t get_threadtask(thread_t th) {
+	return th->task;
+}
+
+// Preemption stubs (normally in arm/machine_routines.c)
+void _disable_preemption(void) {
+	// no-op in Darling
+}
+
+void _enable_preemption(void) {
+	// no-op in Darling
+}
+
+int get_preemption_level(void) {
+	return 0;
+}
+
+// Thread group stubs (normally in arm/machine_routines_common.c)
+void machine_thread_group_blocked(void *tg_blocked, void *tg_blocking, uint32_t flags, thread_t blocked_thread) {
+	// no-op in Darling
+}
+
+void machine_thread_group_unblocked(void *tg_unblocked, void *tg_unblocking, uint32_t flags, thread_t unblocked_thread) {
+	// no-op in Darling
+}
+
+// fls for ARM64
+int
+fls(unsigned int mask)
+{
+	if (mask == 0) {
+		return 0;
+	}
+	return (sizeof(mask) << 3) - __builtin_clz(mask);
+}
+
+#endif /* __aarch64__ || __arm64__ */

--- a/duct-tape/src/misc.c
+++ b/duct-tape/src/misc.c
@@ -155,9 +155,13 @@ fls(unsigned int mask)
 // Darling uses a fixed 4K page size.
 int PAGE_SHIFT_CONST = 12;
 
-// ARM simple lock init (normally in arm/locks_arm.c)
+// ARM simple lock init (normally in arm/locks_arm.c).
+// The arm/simple_lock.h macro `simple_lock_init(l, t)` maps to this;
+// delegate to Darling's usimple_lock_init which properly initializes
+// the embedded lck_spin_t (see src/locks.c).
+extern void usimple_lock_init(usimple_lock_t lock, unsigned short tag);
 void arm_usimple_lock_init(simple_lock_t l, unsigned short type) {
-	memset(l, 0, sizeof(*l));
+	usimple_lock_init((usimple_lock_t)l, type);
 }
 
 // Thread task accessor (normally in kern/bsd_kern.c)
@@ -178,7 +182,9 @@ int get_preemption_level(void) {
 	return 0;
 }
 
-// Thread group stubs (normally in arm/machine_routines_common.c)
+// Thread group stubs (normally in arm/machine_routines_common.c).
+// arm/proc_reg.h sets CONFIG_THREAD_GROUPS=1 on ARM64, so ipc_port_thread_group_*
+// in ipc_port.c will reference these. Darling doesn't implement thread groups.
 void machine_thread_group_blocked(void *tg_blocked, void *tg_blocking, uint32_t flags, thread_t blocked_thread) {
 	// no-op in Darling
 }

--- a/duct-tape/src/processor.c
+++ b/duct-tape/src/processor.c
@@ -98,6 +98,9 @@ kern_return_t processor_info(processor_t processor, processor_flavor_t flavor, h
 #else
 			info->cpu_subtype = CPU_SUBTYPE_I386_ALL;
 #endif
+#elif __aarch64__
+			info->cpu_type = CPU_TYPE_ARM64;
+			info->cpu_subtype = CPU_SUBTYPE_ARM64_ALL;
 #else
 			#error Unknown CPU type
 #endif

--- a/duct-tape/src/rtclock_arm64.c
+++ b/duct-tape/src/rtclock_arm64.c
@@ -1,0 +1,154 @@
+/*
+ * ARM64 rtclock implementation for Darling
+ *
+ * Provides the same clock/time functions as i386/rtclock.c but uses
+ * clock_gettime(CLOCK_MONOTONIC) instead of x86 TSC.
+ */
+
+#include <mach/mach_types.h>
+#include <kern/clock.h>
+#include <kern/misc_protos.h>
+#include <kern/timer_queue.h>
+
+#define CLOCK_MONOTONIC 1
+
+struct timespec {
+	long int tv_sec;
+	long int tv_nsec;
+};
+
+int clock_gettime(int clk_id, struct timespec *tp);
+
+static uint64_t
+rtc_nanotime_read(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * NSEC_PER_SEC + ts.tv_nsec;
+}
+
+static inline uint32_t
+_absolutetime_to_microtime(uint64_t abstime, clock_sec_t *secs, clock_usec_t *microsecs)
+{
+	uint32_t remain;
+	*secs = abstime / (uint64_t)NSEC_PER_SEC;
+	remain = (uint32_t)(abstime % (uint64_t)NSEC_PER_SEC);
+	*microsecs = remain / NSEC_PER_USEC;
+	return remain;
+}
+
+static inline void
+_absolutetime_to_nanotime(uint64_t abstime, clock_sec_t *secs, clock_usec_t *nanosecs)
+{
+	*secs = abstime / (uint64_t)NSEC_PER_SEC;
+	*nanosecs = (clock_usec_t)(abstime % (uint64_t)NSEC_PER_SEC);
+}
+
+void
+rtc_timer_start(void)
+{
+	timer_resync_deadlines();
+}
+
+int
+rtclock_init(void)
+{
+	return 1;
+}
+
+void
+clock_get_system_microtime(
+	clock_sec_t		*secs,
+	clock_usec_t		*microsecs)
+{
+	uint64_t now = rtc_nanotime_read();
+	_absolutetime_to_microtime(now, secs, microsecs);
+}
+
+void
+clock_get_system_nanotime(
+	clock_sec_t		*secs,
+	clock_nsec_t		*nanosecs)
+{
+	uint64_t now = rtc_nanotime_read();
+	_absolutetime_to_nanotime(now, secs, nanosecs);
+}
+
+void
+clock_gettimeofday_set_commpage(uint64_t abstime, uint64_t sec, uint64_t frac, uint64_t scale, uint64_t tick_per_sec)
+{
+	(void)abstime; (void)sec; (void)frac; (void)scale; (void)tick_per_sec;
+}
+
+void
+clock_timebase_info(
+	mach_timebase_info_t info)
+{
+	info->numer = info->denom = 1;
+}
+
+uint64_t
+mach_absolute_time(void)
+{
+	return rtc_nanotime_read();
+}
+
+uint64_t
+mach_approximate_time(void)
+{
+	return rtc_nanotime_read();
+}
+
+void
+clock_interval_to_absolutetime_interval(
+	uint32_t		interval,
+	uint32_t		scale_factor,
+	uint64_t		*result)
+{
+	*result = (uint64_t)interval * scale_factor;
+}
+
+void
+absolutetime_to_microtime(
+	uint64_t		abstime,
+	clock_sec_t		*secs,
+	clock_usec_t		*microsecs)
+{
+	_absolutetime_to_microtime(abstime, secs, microsecs);
+}
+
+void
+nanotime_to_absolutetime(
+	clock_sec_t		secs,
+	clock_nsec_t		nanosecs,
+	uint64_t		*result)
+{
+	*result = ((uint64_t)secs * NSEC_PER_SEC) + nanosecs;
+}
+
+void
+absolutetime_to_nanoseconds(
+	uint64_t		abstime,
+	uint64_t		*result)
+{
+	*result = abstime;
+}
+
+void
+nanoseconds_to_absolutetime(
+	uint64_t		nanoseconds,
+	uint64_t		*result)
+{
+	*result = nanoseconds;
+}
+
+void
+machine_delay_until(
+	uint64_t interval,
+	uint64_t deadline)
+{
+	(void)interval;
+	while (mach_absolute_time() < deadline) {
+		__asm__ volatile("yield");
+	}
+}

--- a/duct-tape/src/rtclock_arm64.c
+++ b/duct-tape/src/rtclock_arm64.c
@@ -10,14 +10,7 @@
 #include <kern/misc_protos.h>
 #include <kern/timer_queue.h>
 
-#define CLOCK_MONOTONIC 1
-
-struct timespec {
-	long int tv_sec;
-	long int tv_nsec;
-};
-
-int clock_gettime(int clk_id, struct timespec *tp);
+#include "linux_clock.h"
 
 static uint64_t
 rtc_nanotime_read(void)

--- a/duct-tape/src/thread.c
+++ b/duct-tape/src/thread.c
@@ -285,7 +285,7 @@ int dtape_thread_save_state_to_user(dtape_thread_t* thread, uintptr_t thread_sta
 		if (copyout(&tstate, thread_state_address, sizeof(tstate)) || copyout(&fstate, float_state_address, sizeof(fstate))) {
 			return -LINUX_EFAULT;
 		}
-	}
+	} else
 #endif
 	if (task->architecture == dserver_rpc_architecture_arm64) {
 		arm_thread_state64_t tstate;
@@ -932,12 +932,21 @@ thread_set_state(
 			}
 			case ARM_THREAD_STATE:
 			{
-				// Unified thread state: auto-select 64-bit for ARM64 tasks
-				arm_thread_state64_t* s64 = (arm_thread_state64_t*) state;
-				if (state_count < ARM_THREAD_STATE64_COUNT)
+				// ARM_THREAD_STATE is the unified flavor. Darwin clients (objc,
+				// WebKit, ...) pass an arm_unified_thread_state_t (header + union);
+				// several Darling-internal RPC paths (signal/exception, workqueue)
+				// pass a bare arm_thread_state64_t. Distinguish by count, the same
+				// way XNU's machine_thread_set_state does.
+				if (state_count >= ARM_UNIFIED_THREAD_STATE_COUNT) {
+					const arm_unified_thread_state_t* u = (const arm_unified_thread_state_t*) state;
+					if (u->ash.flavor != ARM_THREAD_STATE64)
+						return KERN_INVALID_ARGUMENT;
+					memcpy(&user_state->thread_state.ts_64, &u->ts_64, sizeof(u->ts_64));
+				} else if (state_count >= ARM_THREAD_STATE64_COUNT) {
+					memcpy(&user_state->thread_state.ts_64, state, sizeof(arm_thread_state64_t));
+				} else {
 					return KERN_INVALID_ARGUMENT;
-
-				memcpy(&user_state->thread_state.ts_64, s64, sizeof(*s64));
+				}
 				return KERN_SUCCESS;
 			}
 			case ARM_DEBUG_STATE64:
@@ -1233,14 +1242,22 @@ thread_get_state_internal(
 			}
 			case ARM_THREAD_STATE:
 			{
-				// Unified thread state: return 64-bit for ARM64 tasks
-				arm_thread_state64_t* s = (arm_thread_state64_t*) state;
-				if (*state_count < ARM_THREAD_STATE64_COUNT)
+				// Mirror the set path: emit a unified arm_unified_thread_state_t
+				// when the caller's buffer is unified-sized (Darwin clients), else
+				// a bare arm_thread_state64_t for Darling-internal callers.
+				if (*state_count >= ARM_UNIFIED_THREAD_STATE_COUNT) {
+					arm_unified_thread_state_t* u = (arm_unified_thread_state_t*) state;
+					memset(u, 0, sizeof(*u));
+					u->ash.flavor = ARM_THREAD_STATE64;
+					u->ash.count = ARM_THREAD_STATE64_COUNT;
+					memcpy(&u->ts_64, &user_state->thread_state.ts_64, sizeof(u->ts_64));
+					*state_count = ARM_UNIFIED_THREAD_STATE_COUNT;
+				} else if (*state_count >= ARM_THREAD_STATE64_COUNT) {
+					memcpy(state, &user_state->thread_state.ts_64, sizeof(arm_thread_state64_t));
+					*state_count = ARM_THREAD_STATE64_COUNT;
+				} else {
 					return KERN_INVALID_ARGUMENT;
-
-				*state_count = ARM_THREAD_STATE64_COUNT;
-				memcpy(s, &user_state->thread_state.ts_64, sizeof(*s));
-
+				}
 				return KERN_SUCCESS;
 			}
 			case ARM_DEBUG_STATE64:

--- a/duct-tape/src/thread.c
+++ b/duct-tape/src/thread.c
@@ -10,10 +10,21 @@
 #include <kern/ipc_tt.h>
 #include <kern/policy_internal.h>
 #include <mach/thread_act.h>
+#if defined(__aarch64__)
+#include <mach/arm/thread_status.h>
+#include <mach/arm/exception.h>
+#endif
 #include <sys/systm.h>
 #include <sys/ux_exception.h>
 
 #include <stdlib.h>
+
+// On ARM64, arm/cpu_data.h defines current_thread() as a macro expanding to
+// current_thread_fast(). We need to undef it because Darling defines its own
+// current_thread() function and uses dtape_hooks->current_thread().
+#ifdef current_thread
+#undef current_thread
+#endif
 
 #include <rtsig.h>
 
@@ -42,6 +53,8 @@ int thread_max = CONFIG_THREAD_MAX;
 kern_return_t thread_set_state(register thread_t thread, int flavor, thread_state_t state, mach_msg_type_number_t state_count);
 
 kern_return_t thread_get_state(thread_t thread, int flavor, thread_state_t state, mach_msg_type_number_t* state_count);
+
+thread_t current_thread(void);
 
 dtape_thread_t* dtape_thread_create(dtape_task_t* task, uint64_t nsid, void* context) {
 	dtape_thread_t* thread = malloc(sizeof(dtape_thread_t));
@@ -199,6 +212,7 @@ void* dtape_thread_context(dtape_thread_t* thread) {
 int dtape_thread_load_state_from_user(dtape_thread_t* thread, uintptr_t thread_state_address, uintptr_t float_state_address) {
 	dtape_task_t* task = dtape_task_for_thread(thread);
 
+#if __x86_64__ || __i386__
 	if (task->architecture == dserver_rpc_architecture_x86_64) {
 		x86_thread_state64_t tstate;
 		x86_float_state64_t fstate;
@@ -219,6 +233,18 @@ int dtape_thread_load_state_from_user(dtape_thread_t* thread, uintptr_t thread_s
 
 		thread_set_state(current_thread(), x86_THREAD_STATE32, (thread_state_t) &tstate, x86_THREAD_STATE32_COUNT);
 		thread_set_state(current_thread(), x86_FLOAT_STATE32, (thread_state_t) &fstate, x86_FLOAT_STATE32_COUNT);
+	} else
+#endif
+	if (task->architecture == dserver_rpc_architecture_arm64) {
+		arm_thread_state64_t tstate;
+		arm_neon_state64_t fstate;
+
+		if (copyin(thread_state_address, &tstate, sizeof(tstate)) || copyin(float_state_address, &fstate, sizeof(fstate))) {
+			return -LINUX_EFAULT;
+		}
+
+		thread_set_state(current_thread(), ARM_THREAD_STATE64, (thread_state_t) &tstate, ARM_THREAD_STATE64_COUNT);
+		thread_set_state(current_thread(), ARM_NEON_STATE64, (thread_state_t) &fstate, ARM_NEON_STATE64_COUNT);
 	} else {
 		dtape_log_error("dtape_thread_load_state_from_user() unimplemented for architecture: %d", task->architecture);
 		return -LINUX_ENOSYS;
@@ -230,6 +256,7 @@ int dtape_thread_load_state_from_user(dtape_thread_t* thread, uintptr_t thread_s
 int dtape_thread_save_state_to_user(dtape_thread_t* thread, uintptr_t thread_state_address, uintptr_t float_state_address) {
 	dtape_task_t* task = dtape_task_for_thread(thread);
 
+#if __x86_64__ || __i386__
 	if (task->architecture == dserver_rpc_architecture_x86_64) {
 		x86_thread_state64_t tstate;
 		x86_float_state64_t fstate;
@@ -254,6 +281,22 @@ int dtape_thread_save_state_to_user(dtape_thread_t* thread, uintptr_t thread_sta
 
 		count = x86_FLOAT_STATE32_COUNT;
 		thread_get_state(current_thread(), x86_FLOAT_STATE32, (thread_state_t) &fstate, &count);
+
+		if (copyout(&tstate, thread_state_address, sizeof(tstate)) || copyout(&fstate, float_state_address, sizeof(fstate))) {
+			return -LINUX_EFAULT;
+		}
+	}
+#endif
+	if (task->architecture == dserver_rpc_architecture_arm64) {
+		arm_thread_state64_t tstate;
+		arm_neon_state64_t fstate;
+		mach_msg_type_number_t count;
+
+		count = ARM_THREAD_STATE64_COUNT;
+		thread_get_state(current_thread(), ARM_THREAD_STATE64, (thread_state_t) &tstate, &count);
+
+		count = ARM_NEON_STATE64_COUNT;
+		thread_get_state(current_thread(), ARM_NEON_STATE64, (thread_state_t) &fstate, &count);
 
 		if (copyout(&tstate, thread_state_address, sizeof(tstate)) || copyout(&fstate, float_state_address, sizeof(fstate))) {
 			return -LINUX_EFAULT;
@@ -293,11 +336,19 @@ void dtape_thread_process_signal(dtape_thread_t* thread, int bsd_signal_number, 
 			break;
 		case LINUX_SIGBUS:
 			mach_exception = EXC_BAD_ACCESS;
+#if defined(__aarch64__)
+			codes[0] = EXC_ARM_DA_ALIGN;
+#else
 			codes[0] = EXC_I386_ALIGNFLT;
+#endif
 			break;
 		case LINUX_SIGILL:
 			mach_exception = EXC_BAD_INSTRUCTION;
+#if defined(__aarch64__)
+			codes[0] = EXC_ARM_UNDEFINED;
+#else
 			codes[0] = EXC_I386_INVOP;
+#endif
 			break;
 		case LINUX_SIGFPE:
 			mach_exception = EXC_ARITHMETIC;
@@ -305,7 +356,11 @@ void dtape_thread_process_signal(dtape_thread_t* thread, int bsd_signal_number, 
 			break;
 		case LINUX_SIGTRAP:
 			mach_exception = EXC_BREAKPOINT;
+#if defined(__aarch64__)
+			codes[0] = EXC_ARM_BREAKPOINT;
+#else
 			codes[0] = (code == LINUX_SI_KERNEL) ? EXC_I386_BPT : EXC_I386_SGL;
+#endif
 
 			if (code == LINUX_TRAP_HWBKPT) {
 #if 0
@@ -621,6 +676,7 @@ thread_set_state(
 	dtape_task_t* dtask = dtape_task_for_thread(dthread);
 	dtape_thread_user_state_t* user_state = LIST_FIRST(&dthread->user_states);
 
+#if __x86_64__ || __i386__
 	if (dtask->architecture == dserver_rpc_architecture_x86_64 || dtask->architecture == dserver_rpc_architecture_i386) {
 		switch (flavor)
 		{
@@ -850,6 +906,50 @@ thread_set_state(
 				return KERN_INVALID_ARGUMENT;
 		}
 	}
+#endif
+	if (dtask->architecture == dserver_rpc_architecture_arm64) {
+		switch (flavor)
+		{
+			case ARM_THREAD_STATE64:
+			{
+				if (state_count < ARM_THREAD_STATE64_COUNT)
+					return KERN_INVALID_ARGUMENT;
+
+				const arm_thread_state64_t* s = (arm_thread_state64_t*) state;
+
+				memcpy(&user_state->thread_state.ts_64, s, sizeof(*s));
+				return KERN_SUCCESS;
+			}
+			case ARM_NEON_STATE64:
+			{
+				if (state_count < ARM_NEON_STATE64_COUNT)
+					return KERN_INVALID_ARGUMENT;
+
+				const arm_neon_state64_t* s = (arm_neon_state64_t*) state;
+
+				memcpy(&user_state->float_state, s, sizeof(*s));
+				return KERN_SUCCESS;
+			}
+			case ARM_THREAD_STATE:
+			{
+				// Unified thread state: auto-select 64-bit for ARM64 tasks
+				arm_thread_state64_t* s64 = (arm_thread_state64_t*) state;
+				if (state_count < ARM_THREAD_STATE64_COUNT)
+					return KERN_INVALID_ARGUMENT;
+
+				memcpy(&user_state->thread_state.ts_64, s64, sizeof(*s64));
+				return KERN_SUCCESS;
+			}
+			case ARM_DEBUG_STATE64:
+			{
+				// TODO: ARM64 debug state
+				dtape_stub("ARM64 debug state");
+				return KERN_NOT_SUPPORTED;
+			}
+			default:
+				return KERN_INVALID_ARGUMENT;
+		}
+	}
 	return KERN_FAILURE;
 }
 
@@ -869,6 +969,7 @@ thread_get_state_internal(
 	// it currently only does something on ARM64 when the authenticated pointers (`ptrauth_calls`) feature is enabled,
 	// so i think it's safe to say we can ignore it in Darling (even when we get ARM support)
 
+#if __x86_64__ || __i386__
 	if (dtask->architecture == dserver_rpc_architecture_x86_64 || dtask->architecture == dserver_rpc_architecture_i386) {
 		switch (flavor)
 		{
@@ -1097,6 +1198,55 @@ thread_get_state_internal(
 				// TODO
 				return KERN_NOT_SUPPORTED;
 #endif
+			}
+			default:
+				return KERN_INVALID_ARGUMENT;
+		}
+	}
+#endif
+	if (dtask->architecture == dserver_rpc_architecture_arm64) {
+		switch (flavor)
+		{
+			case ARM_THREAD_STATE64:
+			{
+				if (*state_count < ARM_THREAD_STATE64_COUNT)
+					return KERN_INVALID_ARGUMENT;
+
+				arm_thread_state64_t* s = (arm_thread_state64_t*) state;
+				*state_count = ARM_THREAD_STATE64_COUNT;
+
+				memcpy(s, &user_state->thread_state.ts_64, sizeof(*s));
+
+				return KERN_SUCCESS;
+			}
+			case ARM_NEON_STATE64:
+			{
+				if (*state_count < ARM_NEON_STATE64_COUNT)
+					return KERN_INVALID_ARGUMENT;
+
+				arm_neon_state64_t* s = (arm_neon_state64_t*) state;
+				*state_count = ARM_NEON_STATE64_COUNT;
+
+				memcpy(s, &user_state->float_state, sizeof(*s));
+
+				return KERN_SUCCESS;
+			}
+			case ARM_THREAD_STATE:
+			{
+				// Unified thread state: return 64-bit for ARM64 tasks
+				arm_thread_state64_t* s = (arm_thread_state64_t*) state;
+				if (*state_count < ARM_THREAD_STATE64_COUNT)
+					return KERN_INVALID_ARGUMENT;
+
+				*state_count = ARM_THREAD_STATE64_COUNT;
+				memcpy(s, &user_state->thread_state.ts_64, sizeof(*s));
+
+				return KERN_SUCCESS;
+			}
+			case ARM_DEBUG_STATE64:
+			{
+				// TODO: ARM64 debug state
+				return KERN_NOT_SUPPORTED;
 			}
 			default:
 				return KERN_INVALID_ARGUMENT;

--- a/duct-tape/src/timer.c
+++ b/duct-tape/src/timer.c
@@ -6,8 +6,10 @@
 #include <kern/timer_queue.h>
 #include <mach/mach_time.h>
 
+#if __x86_64__ || __i386__
 #include <i386/rtclock_protos.h>
 #include <i386/pal_native.h>
+#endif
 
 #define CLOCK_MONOTONIC 1
 
@@ -32,8 +34,9 @@ struct timespec
 
 int clock_gettime(int clk_id, struct timespec *tp);
 
-// stub
+#if __x86_64__ || __i386__
 pal_rtc_nanotime_t pal_rtc_nanotime_info;
+#endif
 
 int master_cpu = 0;
 
@@ -46,11 +49,13 @@ void dtape_timer_init(void) {
 	mpqueue_init(&timer_queue, LCK_GRP_NULL, LCK_ATTR_NULL);
 };
 
+#if __x86_64__ || __i386__
 uint64_t _rtc_nanotime_read(pal_rtc_nanotime_t* rntp) {
 	struct timespec ts;
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 	return (ts.tv_sec * NSEC_PER_SEC) + ts.tv_nsec;
 };
+#endif
 
 void dtape_timer_fired(void) {
 	uint64_t next_deadline = timer_queue_expire(&timer_queue, mach_absolute_time());

--- a/duct-tape/src/timer.c
+++ b/duct-tape/src/timer.c
@@ -11,28 +11,7 @@
 #include <i386/pal_native.h>
 #endif
 
-#define CLOCK_MONOTONIC 1
-
-// copied from glibc's headers
-struct timespec
-{
-  long int tv_sec;		/* Seconds.  */
-#if __WORDSIZE == 64 \
-  || (defined __SYSCALL_WORDSIZE && __SYSCALL_WORDSIZE == 64) \
-  || __TIMESIZE == 32
-  long int tv_nsec;	/* Nanoseconds.  */
-#else
-# if __BYTE_ORDER == __BIG_ENDIAN
-  int: 32;           /* Padding.  */
-  long int tv_nsec;  /* Nanoseconds.  */
-# else
-  long int tv_nsec;  /* Nanoseconds.  */
-  int: 32;           /* Padding.  */
-# endif
-#endif
-};
-
-int clock_gettime(int clk_id, struct timespec *tp);
+#include "linux_clock.h"
 
 #if __x86_64__ || __i386__
 pal_rtc_nanotime_t pal_rtc_nanotime_info;

--- a/duct-tape/xnu/osfmk/arm/cpu_data.h
+++ b/duct-tape/xnu/osfmk/arm/cpu_data.h
@@ -40,10 +40,13 @@
 #include <kern/kern_types.h>
 #include <kern/processor.h>
 #include <pexpert/pexpert.h>
+#ifndef __DARLING__
 #include <arm/thread.h>
+#endif
 #include <arm/proc_reg.h>
 
 #include <mach/mach_types.h>
+#ifndef __DARLING__
 #include <machine/thread.h>
 
 #define current_thread()        current_thread_fast()
@@ -57,6 +60,10 @@ current_thread_fast(void)
 	return (thread_t)(__builtin_arm_mrc(15, 0, 13, 0, 4));  // TPIDRPRW
 #endif
 }
+#else /* __DARLING__ */
+// Darling provides its own current_thread() function
+extern thread_t current_thread(void);
+#endif /* !__DARLING__ */
 
 /*
  * The "volatile" flavor of current_thread() is intended for use by

--- a/duct-tape/xnu/osfmk/arm/locks.h
+++ b/duct-tape/xnu/osfmk/arm/locks.h
@@ -34,6 +34,9 @@
 #include <arm/hw_lock_types.h>
 #endif
 
+#ifdef __DARLING__
+#include <darlingserver/duct-tape/locks.h>
+#endif // __DARLING__
 
 #ifdef  MACH_KERNEL_PRIVATE
 
@@ -54,10 +57,12 @@
 #endif
 
 #ifdef  MACH_KERNEL_PRIVATE
+#ifndef __DARLING__
 typedef struct {
 	struct hslock   hwlock;
 	uintptr_t               type;
 } lck_spin_t;
+#endif // __DARLING__
 
 #define lck_spin_data hwlock.lock_data
 
@@ -68,16 +73,21 @@ typedef struct {
 #else
 #ifdef  KERNEL_PRIVATE
 
+#ifndef __DARLING__
 typedef struct {
 	uintptr_t               opaque[2];
 } lck_spin_t;
+#endif // __DARLING__
 
 #else
+#ifndef __DARLING__
 typedef struct __lck_spin_t__   lck_spin_t;
+#endif // __DARLING__
 #endif  // KERNEL_PRIVATE
 #endif  // MACH_KERNEL_PRIVATE
 
 #ifdef  MACH_KERNEL_PRIVATE
+#ifndef __DARLING__
 typedef struct _lck_mtx_ {
 	union {
 		uintptr_t                                       lck_mtx_data;   /* Thread pointer plus lock bits */
@@ -94,6 +104,7 @@ typedef struct _lck_mtx_ {
 		};
 	};                                                                                              /* arm: 4   arm64: 8 */
 } lck_mtx_t;                                                                            /* arm: 8  arm64: 16 */
+#endif // __DARLING__
 
 /* Shared between mutex and read-write locks */
 #define LCK_ILOCK_BIT           0
@@ -142,9 +153,11 @@ typedef struct _lck_mtx_ext_ {
 
 #else
 #ifdef  KERNEL_PRIVATE
+#ifndef __DARLING__
 typedef struct {
 	uintptr_t        opaque[2];
 } lck_mtx_t;
+#endif // __DARLING__
 
 typedef struct {
 #if defined(__arm64__)
@@ -155,7 +168,9 @@ typedef struct {
 } lck_mtx_ext_t;
 
 #else
+#ifndef __DARLING__
 typedef struct __lck_mtx_t__    lck_mtx_t;
+#endif // __DARLING__
 #endif
 #endif
 

--- a/duct-tape/xnu/osfmk/arm/simple_lock.h
+++ b/duct-tape/xnu/osfmk/arm/simple_lock.h
@@ -76,7 +76,11 @@
 extern uint32_t LockTimeOut;                    /* Number of hardware ticks of a lock timeout */
 extern uint32_t LockTimeOutUsec;                /* Number of microseconds for lock timeout */
 
+#ifdef __DARLING__
+#include <darlingserver/duct-tape/simple_lock.h>
+#else
 typedef lck_spin_t usimple_lock_data_t, *usimple_lock_t;
+#endif // __DARLING__
 #else /* MACH_KERNEL_PRIVATE */
 
 #if defined(__arm__)

--- a/duct-tape/xnu/osfmk/arm/thread.h
+++ b/duct-tape/xnu/osfmk/arm/thread.h
@@ -85,8 +85,12 @@ typedef arm_kernel_context_t machine_thread_kernel_state;
 #else
 typedef struct arm_saved_state machine_thread_kernel_state;
 #endif
-#include <kern/thread_kernel_state.h>
 
+// NOTE: struct machine_thread must be defined BEFORE including
+// thread_kernel_state.h. On Darling, that header transitively pulls in
+// kern/task.h -> kern/thread.h, which embeds `struct machine_thread machine`
+// by value — so the struct must be complete at that point. (On upstream XNU
+// vm_kern.h does not include task.h, so the circular dependency doesn't arise.)
 struct machine_thread {
 #if __ARM_USER_PROTECT__
 	unsigned int              uptw_ttb;
@@ -164,7 +168,9 @@ struct machine_thread {
 	uint64_t                  reserved10;
 #endif
 };
-#endif
+
+#include <kern/thread_kernel_state.h>
+#endif /* MACH_KERNEL_PRIVATE */
 
 extern struct arm_saved_state *    get_user_regs(thread_t);
 extern struct arm_saved_state *    find_user_regs(thread_t);

--- a/duct-tape/xnu/osfmk/kern/waitq.h
+++ b/duct-tape/xnu/osfmk/kern/waitq.h
@@ -67,8 +67,17 @@ typedef enum e_waitq_lock_state {
 		#define WQ_OPAQUE_SIZE   32
 		#define WQS_OPAQUE_SIZE  48
 	#else
-		#define WQ_OPAQUE_SIZE   40
-		#define WQS_OPAQUE_SIZE  56
+		#ifdef __DARLING__
+			#undef WQ_OPAQUE_ALIGN
+			#undef WQS_OPAQUE_ALIGN
+			#define WQ_OPAQUE_ALIGN   8
+			#define WQS_OPAQUE_ALIGN  8
+			#define WQ_OPAQUE_SIZE   72
+			#define WQS_OPAQUE_SIZE  88
+		#else
+			#define WQ_OPAQUE_SIZE   40
+			#define WQS_OPAQUE_SIZE  56
+		#endif
 	#endif
 #elif __x86_64__
 	#define WQ_OPAQUE_ALIGN   8

--- a/duct-tape/xnu/osfmk/libsa/arm/types.h
+++ b/duct-tape/xnu/osfmk/libsa/arm/types.h
@@ -56,7 +56,7 @@
 #ifndef _MACH_MACHINE_TYPES_H_
 #define _MACH_MACHINE_TYPES_H_ 1
 
-typedef long            dev_t;          /* device number (major+minor) */
+typedef int             dev_t;          /* device number (major+minor) */
 
 typedef signed char     bit8_t;         /* signed 8-bit quantity */
 typedef unsigned char   u_bit8_t;       /* unsigned 8-bit quantity */

--- a/duct-tape/xnu/osfmk/vm/vm_map.h
+++ b/duct-tape/xnu/osfmk/vm/vm_map.h
@@ -1566,12 +1566,12 @@ static inline bool
 VM_MAP_IS_EXOTIC(
 	vm_map_t map __unused)
 {
-#if __arm64__
+#if __arm64__ && !defined(__DARLING__)
 	if (VM_MAP_PAGE_SHIFT(map) < PAGE_SHIFT ||
 	    pmap_is_exotic(map->pmap)) {
 		return true;
 	}
-#endif /* __arm64__ */
+#endif /* __arm64__ && !__DARLING__ */
 	return false;
 }
 

--- a/duct-tape/xnu/pexpert/pexpert/arm64/VMAPPLE.h
+++ b/duct-tape/xnu/pexpert/pexpert/arm64/VMAPPLE.h
@@ -37,7 +37,7 @@
 
 #define CPU_HAS_APPLE_PAC         1
 #define HAS_PARAVIRTUALIZED_PAC   1
-#define 1
+/* #define ??? 1 -- broken line in original XNU source */
 #define HAS_GIC_V3                1
 
 #define __ARM_PAN_AVAILABLE__     1

--- a/src/darlingserver.cpp
+++ b/src/darlingserver.cpp
@@ -701,6 +701,16 @@ int main(int argc, char** argv) {
 
 		close(childWaitFDs[1]);
 
+		// Detach launchd into its own session + process group, so that any
+		// signals it (or its children) broadcast via kill(0/-1, ...) or
+		// killpg(0, ...) do not propagate back up to darlingserver / darling /
+		// timeout (which all share the same pgrp by default). On ARM64 we
+		// observed launchd's startup broadcasting SIGTRAP, killing the parents.
+		if (setsid() == (pid_t)-1) {
+			fprintf(stderr, "Warning: setsid() failed before launchd: %s\n", strerror(errno));
+			// continue anyway
+		}
+
 		snprintf(putOld, sizeof(putOld), "%s/proc", prefix);
 
 		// mount procfs for our new PID namespace

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -47,6 +47,10 @@
 #include <sys/user.h>
 #include <sys/wait.h>
 #include <vector>
+#if defined(__aarch64__)
+#include <sys/uio.h>
+#include <elf.h>
+#endif
 
 // 64KiB should be enough for us
 #define THREAD_STACK_SIZE (64 * 1024ULL)
@@ -145,16 +149,23 @@ DarlingServer::Thread::Thread(std::shared_ptr<Process> process, NSID nsid, void*
 					continue;
 				}
 
+#if defined(__aarch64__)
+				struct user_regs_struct regs;
+				struct iovec iov = { &regs, sizeof(regs) };
+				if (ptrace(PTRACE_GETREGSET, id, (void*)NT_PRSTATUS, &iov) == -1) {
+					continue;
+				}
+				intptr_t stackDiff = (intptr_t)stackHint - (intptr_t)regs.sp;
+				if (stackDiff >= 0 && stackDiff < nearest) {
+#elif defined(__x86_64__)
 				struct user_regs_struct regs;
 				if (ptrace(PTRACE_GETREGS, id, 0, &regs) == -1) {
 					continue;
 				}
-
-#ifdef __x86_64__
 				intptr_t stackDiff = (intptr_t)stackHint - (intptr_t)regs.rsp;
 				if (stackDiff >= 0 && stackDiff < nearest) {
 #else
-	#warning Unsupported architecture
+	#error Unsupported architecture
 				if (true) {
 #endif
 					chosenId = id;


### PR DESCRIPTION
On ARM64 launchd's early startup broadcasts signals via `kill(0/-1, ...)` and `killpg(0, ...)`. These propagate back to `darlingserver` / the `darling` wrapper / `timeout` because they share the same pgrp by default, killing the whole test harness.

Call `setsid()` after the fork-and-before-execve point of `launchd`, so launchd's process group is fresh and its signal broadcasts stay contained. Warn-and-continue on failure.

Part of the ARM64 support series; the umbrella PR in `darlinghq/darling` references the rest.